### PR TITLE
style facet labels in theme_mdr

### DIFF
--- a/R/theme_mdr.R
+++ b/R/theme_mdr.R
@@ -24,6 +24,8 @@ theme_mdr <- function() {
       axis.title = ggplot2::element_text(color = "#CFE0E1", size = 12),
       axis.text = ggplot2::element_text(color = "#CFE0E1", size = 10),
       axis.line = ggplot2::element_line(color = "#CFE0E1"),
+      # facets
+      strip.text = ggplot2::element_text(color = "#CFE0E1", size = 12),
       # legend
       legend.title = ggplot2::element_text(color = "#CFE0E1"),
       legend.text = ggplot2::element_text(color = "#CFE0E1"),


### PR DESCRIPTION
By default, the text colour of facet labels is very close to the background:

![Dark grey text on black background](https://github.com/user-attachments/assets/7fdaa8d5-fd47-46c5-bf78-978f14e9a961)

This PR uses a contrasting colour instead:

![Larger, white text](https://github.com/user-attachments/assets/52933d35-03d9-4e8e-93e4-2616359d6566)
